### PR TITLE
Fixed build error caused by reticle fix

### DIFF
--- a/Runtime/Scripts/AryzonManager.cs
+++ b/Runtime/Scripts/AryzonManager.cs
@@ -481,7 +481,9 @@ namespace Aryzon
 
         private void OnDestroy()
         {
-            if (editorPoseProvider) Destroy(editorPoseProvider.gameObject);
+#if UNITY_EDITOR
+	        if (editorPoseProvider) Destroy(editorPoseProvider.gameObject);
+#endif
         }
     }
 


### PR DESCRIPTION
There's a missing precompiler statement in the AryzonManager.cs that prevents building, this pullrequest adds it.